### PR TITLE
feat: save results to out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
-pieces.txt
+/pieces.txt
 .vscode
 Dockerfile.custom
 *.crt
+/out

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ performance data in grafana, which will remain running after the load test shuts
 
 Visit: `http://localhost:3000/` and navigate to the `k6 performance test` dashboard.
 
+Alternatively, a load test summary JSON file will also be created in the `/out` directory of the project.
+
 ## Developing Scripts
 
 During development, it might be easier to run scripts without the load testing setup that `loadtest.sh` provides. In this case, you can use the `runscript.sh` command to run any k6 script.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you don't already have pieces you can test downloads against, `generateDeals.
 command run:
 
 ```
-./generateDeals.sh [number of deals] [folder to store car files] [minerID]
+$ ./generateDeals.sh [number of deals] [folder to store car files] [minerID]
 ```
 
 Storage deals are a sensitive process and this script may require additional configuration on your miner
@@ -47,29 +47,45 @@ The load test reads configuration from environment variables in the .env file us
 Before you run the load test for the first time, you should run:
 
 ```
-cp .env.example .env
+$ cp .env.example .env
 ```
 
 You will need to edit .env to set at least one of the config options -- the BOOST_FETCH_URL which is the base URL which piece IDs are appended to fetch pieces from Boost
 
-## Usage
+## Load Testing
 
 To run a load test, run:
 
 ```
-./loadtest.sh
+$ ./loadtest.sh
 ```
 
 optionally, if you'd like to run your load test directly on the host machine, you can run
 
 ```
-RAW_LOAD_TEST=1 ./loadtest.sh
+$ RAW_LOAD_TEST=1 ./loadtest.sh
 ```
 
 Your load test will display output as it runs. Once it's complete, you can view
 performance data in grafana, which will remain running after the load test shuts down.
 
 Visit: `http://localhost:3000/` and navigate to the `k6 performance test` dashboard.
+
+## Developing Scripts
+
+During development, it might be easier to run scripts without the load testing setup that `loadtest.sh` provides. In this case, you can use the `runscript.sh` command to run any k6 script.
+
+To run a k6 script, run:
+
+```
+$ ./runscript.sh <absolute-path-of-script-on-container>
+```
+
+The scripts in the local `./scripts` directory are loaded onto the k6 container in the root directory `/scripts` when the image is started. To run the local script `./scripts/example.js`, the argument would be `/scripts/example.js`. Notice the lack of the period (.) at the start of the path since we're referencing the absolute path to the script on the k6 container.
+
+```
+$ ./runscript.sh /scripts/example.js
+```
 
 ## Contribute
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,4 +43,6 @@ services:
       - RAW_FETCH_URL
     volumes:
       - ./scripts:/scripts
+      - ./out:/out
       - ./pieces.txt:/pieces.txt
+    user: ${UID}:${GID}

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -6,9 +6,9 @@ docker compose up -d influxdb grafana
 for CONCURRENCY in "${TEST_CONCURRENCIES[@]}"
 do
    if [[ -z "${RAW_LOAD_TEST}" ]]; then
-      SIMULTANEOUS_DOWNLOADS=$CONCURRENCY docker compose run k6 run --verbose /scripts/script.js
+      UID=${UID} GID=${GID} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY docker compose run k6 run --verbose /scripts/script.js
    else
       source .env
-      K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY k6 run --verbose ./scripts/script.js
+      UID=${UID} GID=${GID} K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY k6 run --verbose ./scripts/script.js
    fi
 done

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -2,13 +2,15 @@
 
 TEST_CONCURRENCIES=(1 8 16 32 64)
 
+mkdir -p out
+
 docker compose up -d influxdb grafana
 for CONCURRENCY in "${TEST_CONCURRENCIES[@]}"
 do
    if [[ -z "${RAW_LOAD_TEST}" ]]; then
-      UID=${UID} GID=${GID} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY docker compose run k6 run --verbose /scripts/script.js
+      SIMULTANEOUS_DOWNLOADS=$CONCURRENCY docker compose run k6 run --verbose /scripts/script.js
    else
       source .env
-      UID=${UID} GID=${GID} K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY k6 run --verbose ./scripts/script.js
+      K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY k6 run --verbose ./scripts/script.js
    fi
 done

--- a/runscript.sh
+++ b/runscript.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker compose up -d influxdb grafana
+docker compose run --rm -i --volume "$(pwd)/out":/out --workdir "/out" k6 run $1

--- a/runscript.sh
+++ b/runscript.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 docker compose up -d influxdb grafana
+mkdir -p out
 docker compose run --rm -i --volume "$(pwd)/out":/out --workdir "/out" k6 run $1

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -2,6 +2,7 @@ import http from 'k6/http'
 import { SharedArray } from 'k6/data'
 import encoding from 'k6/encoding'
 import { Trend, Rate } from 'k6/metrics'
+import dayjs from 'https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js'
 
 const pieces = new SharedArray('pieces', function () {
   // here you can open files, and then do additional processing or generate the array with data dynamically
@@ -70,4 +71,17 @@ export default function () {
     timeDelta.add(boostResponse.timings.duration - rawResponse.timings.duration)
     ttfbDelta.add(boostResponse.timings.waiting - rawResponse.timings.waiting)
   }
+}
+
+const OUT_DIR = "/out";
+const TEST_NAME = "script";
+
+export function handleSummary(data) {
+  const timeStr = dayjs().format("YYYY-MM-DDTHH:mm:ss")
+  const filepath = `/${OUT_DIR}/${TEST_NAME}-${timeStr}.json`;
+
+  return {
+    'stdout': textSummary(data, { indent: "  ", enableColors: true }),
+    [filepath]: JSON.stringify(data, null, 2),
+  };
 }

--- a/scripts/summary.js
+++ b/scripts/summary.js
@@ -1,0 +1,20 @@
+import http from 'k6/http';
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
+import dayjs from 'https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js'
+
+export default function () {
+  http.get('https://test.k6.io');
+}
+
+const OUT_DIR = "/out";
+const TEST_NAME = "summary";
+
+export function handleSummary(data) {
+  const timeStr = dayjs().format("YYYY-MM-DDTHH:mm:ss")
+  const filepath = `/${OUT_DIR}/${TEST_NAME}-${timeStr}.json`;
+
+  return {
+    'stdout': textSummary(data, { indent: "  ", enableColors: true }),
+    [filepath]: JSON.stringify(data, null, 2),
+  };
+}


### PR DESCRIPTION
This PR updates the script.js to output to an `/out` directory, as well as output the default summary output to stdout.

#### Notable Changes
- The local machine's user UID and GID were needed to allow the docker container to save files to the local filesystem.
- An `/out` directory is now mounted as a volume so that the script running in the k6 docker container can save the summary file on the local machine's filesystem, otherwise it just saves the summary file in the container where it can't be accessed.

Resolves issue #1 