### PR TITLE
Add boost and raw fetch data received and bandwidth metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ You will need to edit .env to set at least one of the config options -- the BOOS
 
 ## Load Testing
 
-To run a load test, run:
+To run a load test using the host machine's local k6 runner, run:
 
 ```
 $ ./loadtest.sh
 ```
 
-optionally, if you'd like to run your load test directly on the host machine, you can run
+optionally, if you'd like to run your load test using the docker image, you can run
 
 ```
-$ RAW_LOAD_TEST=1 ./loadtest.sh
+$ USE_DOCKER_K6=1 ./loadtest.sh
 ```
 
 Your load test will display output as it runs. Once it's complete, you can view

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -7,10 +7,10 @@ mkdir -p out
 docker compose up -d influxdb grafana
 for CONCURRENCY in "${TEST_CONCURRENCIES[@]}"
 do
-   if [[ -z "${RAW_LOAD_TEST}" ]]; then
-      SIMULTANEOUS_DOWNLOADS=$CONCURRENCY docker compose run k6 run --verbose /scripts/script.js
-   else
+   if [[ -z "${USE_DOCKER_K6}" ]]; then
       source .env
-      K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY k6 run --verbose ./scripts/script.js
+      K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY OUT_DIR="./out" k6 run --http-debug ./scripts/script.js
+   else
+      SIMULTANEOUS_DOWNLOADS=$CONCURRENCY OUT_DIR="/out" docker compose run k6 run --http-debug /scripts/script.js
    fi
 done

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -1,7 +1,7 @@
 import http from 'k6/http'
 import { SharedArray } from 'k6/data'
-import encoding from 'k6/encoding'
-import { Trend, Rate } from 'k6/metrics'
+import { Trend, Rate, Counter } from 'k6/metrics'
+import { textSummary } from 'https://jslib.k6.io/k6-summary/0.0.3/index.js'
 import dayjs from 'https://cdn.jsdelivr.net/npm/dayjs@1/dayjs.min.js'
 
 const pieces = new SharedArray('pieces', function () {
@@ -13,14 +13,18 @@ const pieces = new SharedArray('pieces', function () {
   return arr // f must be an array[]
 })
 
-const timeBoost = new Trend('time-boost')
-const ttfbBoost = new Trend('ttfb-boost')
-const timeRaw = new Trend('time-raw')
-const ttfbRaw = new Trend('ttfb-raw')
-const timeDelta = new Trend('time-delta')
-const ttfbDelta = new Trend('ttfb-delta')
-const boostSuccess = new Rate('success-boost')
-const rawSuccess = new Rate('success-raw')
+const bandwidthBoost = new Trend('bandwidth_boost')
+const bandwidthRaw = new Trend('bandwidth_raw')
+const dataReceivedBoost = new Counter('data_received_boost')
+const dataReceivedRaw = new Counter('data_received_raw')
+const timeBoost = new Trend('time_boost')
+const timeDelta = new Trend('time_delta')
+const timeRaw = new Trend('time_raw')
+const ttfbBoost = new Trend('ttfb_boost')
+const ttfbDelta = new Trend('ttfb_delta')
+const ttfbRaw = new Trend('ttfb_raw')
+const boostSuccess = new Rate('success_boost')
+const rawSuccess = new Rate('success_raw')
 
 export const options = {
   scenarios: {
@@ -37,48 +41,70 @@ export const options = {
 export default function () {
   // get a random piece from the list
   const piece = pieces[Math.floor(Math.random() * pieces.length)]
-  // run raw vs boost randomly first
-  const runRawFirst = Math.round(Math.random())
+
+  // randomly fetch first from either a raw url or boost
+  const fetchRawUrlFirst = Math.random() >= .5
   let boostResponse, rawResponse
-  for (let i = 0; i < 2; i++) {
-    if ((i + runRawFirst) % 2 === 0) {
-      boostResponse = http.get(`${__ENV.BOOST_FETCH_URL}${piece}`, {
-        tags: {
-          name: 'BoostFetchURL',
-        },
-        timeout: `${__ENV.SIMULTANEOUS_DOWNLOADS}h`,
-      })
-      timeBoost.add(boostResponse.timings.duration)
-      ttfbBoost.add(boostResponse.timings.waiting)
-      boostSuccess.add(
-        boostResponse.status >= 200 && boostResponse.status < 300
-      )
-    } else {
-      if (__ENV.RAW_FETCH_URL) {
-        rawResponse = http.get(`${__ENV.RAW_FETCH_URL}${piece}`, {
-          tags: {
-            name: 'RawFetchURL',
-          },
-          timeout: `${__ENV.SIMULTANEOUS_DOWNLOADS}h`,
-        })
-        timeRaw.add(rawResponse.timings.duration)
-        ttfbRaw.add(rawResponse.timings.waiting)
-        rawSuccess.add(rawResponse.status >= 200 && rawResponse.status < 300)
-      }
-    }
+
+  if (fetchRawUrlFirst) {
+    rawResponse = fetchFromRawUrl(piece)
+    boostResponse = fetchFromBoost(piece)
+  } else {
+    boostResponse = fetchFromBoost(piece)
+    rawResponse = fetchFromRawUrl(piece)
   }
+
   if (__ENV.RAW_FETCH_URL) {
     timeDelta.add(boostResponse.timings.duration - rawResponse.timings.duration)
     ttfbDelta.add(boostResponse.timings.waiting - rawResponse.timings.waiting)
   }
 }
 
-const OUT_DIR = "/out";
+function fetchFromBoost(piece) {
+  let response = http.get(`${__ENV.BOOST_FETCH_URL}${piece}`, {
+    tags: {
+      name: 'BoostFetchURL',
+    },
+    timeout: `${__ENV.SIMULTANEOUS_DOWNLOADS}h`,
+  })
+  timeBoost.add(response.timings.duration)
+  ttfbBoost.add(response.timings.waiting)
+  boostSuccess.add(
+    response.status >= 200 && response.status < 300
+  )
+
+  let contentLength = parseInt(response.headers['Content-Length'])
+  dataReceivedBoost.add(contentLength, { url: response.url })
+  bandwidthBoost.add(contentLength / response.timings.duration)
+
+  return response
+}
+
+function fetchFromRawUrl(piece) {
+  if (__ENV.RAW_FETCH_URL) {
+    let response = http.get(`${__ENV.RAW_FETCH_URL}${piece}`, {
+      tags: {
+        name: 'RawFetchURL',
+      },
+      timeout: `${__ENV.SIMULTANEOUS_DOWNLOADS}h`,
+    })
+    timeRaw.add(response.timings.duration)
+    ttfbRaw.add(response.timings.waiting)
+    rawSuccess.add(response.status >= 200 && response.status < 300)
+
+    let contentLength = parseInt(response.headers['Content-Length'])
+    dataReceivedRaw.add(contentLength, { url: response.url })
+    bandwidthRaw.add(contentLength / response.timings.duration)
+
+    return response
+  }
+}
+
 const TEST_NAME = "script";
 
 export function handleSummary(data) {
   const timeStr = dayjs().format("YYYY-MM-DDTHH:mm:ss")
-  const filepath = `/${OUT_DIR}/${TEST_NAME}-${timeStr}.json`;
+  const filepath = `${__ENV.OUT_DIR}/${TEST_NAME}-${timeStr}.json`;
 
   return {
     'stdout': textSummary(data, { indent: "  ", enableColors: true }),

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -13,16 +13,16 @@ const pieces = new SharedArray('pieces', function () {
   return arr // f must be an array[]
 })
 
-const bandwidthBoost = new Trend('bandwidth_boost')
-const bandwidthRaw = new Trend('bandwidth_raw')
+const bytesPerMsBoost = new Trend('bytes_per_ms_boost')
+const bytesPerMsRaw = new Trend('bytes_per_ms_raw')
 const dataReceivedBoost = new Counter('data_received_boost')
 const dataReceivedRaw = new Counter('data_received_raw')
-const timeBoost = new Trend('time_boost')
-const timeDelta = new Trend('time_delta')
-const timeRaw = new Trend('time_raw')
-const ttfbBoost = new Trend('ttfb_boost')
-const ttfbDelta = new Trend('ttfb_delta')
-const ttfbRaw = new Trend('ttfb_raw')
+const timeBoost = new Trend('time_boost', true)
+const timeDelta = new Trend('time_delta', true)
+const timeRaw = new Trend('time_raw', true)
+const ttfbBoost = new Trend('ttfb_boost', true)
+const ttfbDelta = new Trend('ttfb_delta', true)
+const ttfbRaw = new Trend('ttfb_raw', true)
 const boostSuccess = new Rate('success_boost')
 const rawSuccess = new Rate('success_raw')
 
@@ -75,7 +75,7 @@ function fetchFromBoost(piece) {
 
   let contentLength = parseInt(response.headers['Content-Length'])
   dataReceivedBoost.add(contentLength, { url: response.url })
-  bandwidthBoost.add(contentLength / response.timings.duration)
+  bytesPerMsBoost.add(contentLength / response.timings.duration)
 
   return response
 }
@@ -94,7 +94,7 @@ function fetchFromRawUrl(piece) {
 
     let contentLength = parseInt(response.headers['Content-Length'])
     dataReceivedRaw.add(contentLength, { url: response.url })
-    bandwidthRaw.add(contentLength / response.timings.duration)
+    bytesPerMsRaw.add(contentLength / response.timings.duration)
 
     return response
   }


### PR DESCRIPTION
Adds the following metrics:
- data_received_boost - The total data received from the boost fetch url
- data_received_raw - The total data received from the raw fetch url
- bytes_per_ms_boost - The average, minimum, median, max, p90, and p95 bandwidth values for data received from the boost fetch url.
- bytes_per_ms_raw - The average, minimum, median, max, p90, and p95 bandwidth values for data received from the raw fetch url

**Note:** `bytes_per_ms_*` metrics were named `bandwidth_*`, but the inability to add custom units to the output led to the decision to change the metric name to include units.

Example stdout output:
![image](https://user-images.githubusercontent.com/3432646/212007734-7aad47cd-8e0a-42ae-bb73-9fee291a8316.png)


#### Other Changes
- Changed `RAW_LOAD_TEST` to `USE_DOCKER_K6` to be more explicit and to distinguish that `RAW_FETCH_URL` and `RAW_LOAD_TEST` are not related to each other
- Removed K6 --verbose option in favor of --http-debug option. I'm sure we'll continue to add/remove these as we find them useful until we implement a way to make them easily optional in the k6 run command.
- Updated how the summary 'out' directory is defined due to the difference in pathing when running in docker versus the native k6 runner
- Replaces dashes (`-`) in metrics names in favor of underscores (`_`) to stay consistent with K6 native metrics and keep the metrics alphabetized in the summary
- Added `ms` time units to appropriate custom time metrics
- Pulls fetching from boost and raw fetch urls into their own functions
- Simplifies logic surrounding fetching from the raw fetch url first

Resolves issue #5 