### PR TITLE
Write summary files to more descriptive locations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - SIMULTANEOUS_DOWNLOADS
       - RANGE_SIZE
       - TEST_NAME
+      - OUT_DIR
       - BOOST_FETCH_URL
       - RAW_FETCH_URL
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - K6_OUT=influxdb=http://influxdb:8086/k6
       - SIMULTANEOUS_DOWNLOADS
       - RANGE_SIZE
+      - TEST_NAME
       - BOOST_FETCH_URL
       - RAW_FETCH_URL
     volumes:

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+rm -rf out
+
 mkdir -p out
 docker compose up -d influxdb grafana
 

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -14,9 +14,18 @@ for CONCURRENCY in "${TEST_CONCURRENCIES[@]}"
 do
   if [[ -z "${USE_DOCKER_K6}" ]]; then
     source .env
-    K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY OUT_DIR="./out" k6 run ./scripts/script.js
+    K6_OUT=influxdb=http://127.0.0.1:8086/k6 \
+    BOOST_FETCH_URL=${BOOST_FETCH_URL} \
+    RAW_FETCH_URL=${RAW_FETCH_URL} \
+    TEST_NAME=$TEST_NAME \
+    SIMULTANEOUS_DOWNLOADS=$CONCURRENCY \
+    OUT_DIR="./out" \
+    k6 run ./scripts/script.js
   else
-    SIMULTANEOUS_DOWNLOADS=$CONCURRENCY OUT_DIR="/out" docker compose run k6 run /scripts/script.js
+    TEST_NAME=$TEST_NAME \
+    SIMULTANEOUS_DOWNLOADS=$CONCURRENCY \
+    OUT_DIR="/out" \
+    docker compose run k6 run /scripts/script.js
   fi
 done
 
@@ -32,9 +41,20 @@ do
   do
     if [[ -z "${USE_DOCKER_K6}" ]]; then
       source .env
-      K6_OUT=influxdb=http://127.0.0.1:8086/k6 BOOST_FETCH_URL=${BOOST_FETCH_URL} RAW_FETCH_URL=${RAW_FETCH_URL} SIMULTANEOUS_DOWNLOADS=$CONCURRENCY RANGE_SIZE=$RANGE_SIZE OUT_DIR="./out" k6 run ./scripts/script.js
+      K6_OUT=influxdb=http://127.0.0.1:8086/k6 \
+      BOOST_FETCH_URL=${BOOST_FETCH_URL} \
+      RAW_FETCH_URL=${RAW_FETCH_URL} \
+      TEST_NAME=$TEST_NAME \
+      SIMULTANEOUS_DOWNLOADS=$CONCURRENCY \
+      RANGE_SIZE=$RANGE_SIZE \
+      OUT_DIR="./out" \
+      k6 run ./scripts/script.js
     else
-      SIMULTANEOUS_DOWNLOADS=$CONCURRENCY RANGE_SIZE=$RANGE_SIZE OUT_DIR="/out" docker compose run k6 run /scripts/script.js
+      TEST_NAME=$TEST_NAME \
+      SIMULTANEOUS_DOWNLOADS=$CONCURRENCY \
+      RANGE_SIZE=$RANGE_SIZE \
+      OUT_DIR="/out" \
+      docker compose run k6 run /scripts/script.js
     fi
   done
 done

--- a/loadtest.sh
+++ b/loadtest.sh
@@ -3,6 +3,9 @@
 mkdir -p out
 docker compose up -d influxdb grafana
 
+TEST_NAME="full-fetch"
+mkdir -p out/"${TEST_NAME}"
+
 TEST_CONCURRENCIES=(1 8 16 32 64)
 
 for CONCURRENCY in "${TEST_CONCURRENCIES[@]}"
@@ -14,6 +17,9 @@ do
     SIMULTANEOUS_DOWNLOADS=$CONCURRENCY OUT_DIR="/out" docker compose run k6 run /scripts/script.js
   fi
 done
+
+TEST_NAME="range-requests"
+mkdir -p out/"${TEST_NAME}"
 
 TEST_RANGE_CONCURRENCIES=(10 100 1000)
 RANGE_SIZES=(1048576 10485760 104857600)

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -171,7 +171,7 @@ export function handleSummary(data) {
   }
 
   return {
-    'stdout': textSummary(data, { indent: '  ', enableColors: true }),
+    'stdout': textSummary(data, { indent: '  ', enableColors: true }) + '\n',
     [filepath]: JSON.stringify(data, null, 2),
   }
 }

--- a/scripts/script.js
+++ b/scripts/script.js
@@ -156,15 +156,22 @@ function getRangeHeaderValue(rangeSize, maxContentSize=34359738368) {
 }
 
 /**
- * Defines a custom K6 summary output configuration
+ * Defines a custom K6 summary output configuration.
+ * Configuration changes based on test name.
  */
-const TEST_NAME = 'script';
 export function handleSummary(data) {
   const timeStr = dayjs().format('YYYY-MM-DDTHH:mm:ss')
-  const filepath = `${__ENV.OUT_DIR}/${TEST_NAME}-${timeStr}.json`;
+  var filepath
+
+  if (__ENV.TEST_NAME === 'full-fetch') {
+    filepath = `${__ENV.OUT_DIR}/${__ENV.TEST_NAME}/${__ENV.SIMULTANEOUS_DOWNLOADS}vu_${timeStr}.json`
+  }
+  else if (__ENV.TEST_NAME === 'range-requests') {
+    filepath = `${__ENV.OUT_DIR}/${__ENV.TEST_NAME}/${__ENV.SIMULTANEOUS_DOWNLOADS}vu_${__ENV.RANGE_SIZE}B_${timeStr}.json`
+  }
 
   return {
     'stdout': textSummary(data, { indent: '  ', enableColors: true }),
     [filepath]: JSON.stringify(data, null, 2),
-  };
+  }
 }


### PR DESCRIPTION
NOTE: This PR builds on top of infrastructure changes built on the feat/range-requests branch

After adding range tests, it became clear that the summary file names were not useful anymore. This updates directories and file names to be more descriptive with the type of test and test parameters.

This also deletes the `out` directory when starting the tests to account for the work that needs to be done in #7. In this way all of the json files can be read without having to know their names.

Directory of summary files
![image](https://user-images.githubusercontent.com/3432646/212019970-0b1d4f51-a111-44f3-bbc0-bf005d17b3d0.png)

Resolves #1 